### PR TITLE
Make installation and uninstallation non interactive on Debian and Ubuntu

### DIFF
--- a/scripts/detect-os-and-install.sh
+++ b/scripts/detect-os-and-install.sh
@@ -2,12 +2,14 @@
 
 detect=$(cat /etc/*-release | grep 'ID=')
 if [[ $detect == *"debian"* ]]; then
+  export DEBIAN_FRONTEND=noninteractive
 	apt-get update
-	apt-get install clamav
+	apt-get --assume-yes install clamav
 	sed -i -e "s/^Example/#Example/" /etc/freshclam.conf
 elif [[ $detect == *"ubuntu"* ]]; then
+  export DEBIAN_FRONTEND=noninteractive
 	apt-get update
-	apt-get install clamav
+	apt-get --assume-yes install clamav
 	sed -i -e "s/^Example/#Example/" /etc/freshclam.conf
 elif [[ $detect == *"centos"* ]]; then
     yum install -y epel-release 

--- a/scripts/detect-os-and-uninstall.sh
+++ b/scripts/detect-os-and-uninstall.sh
@@ -2,9 +2,11 @@
 
 detect=$(cat /etc/*-release | grep 'ID=')
 if [[ $detect == *"debian"* ]]; then
-	sudo apt-get remove clamav
+  export DEBIAN_FRONTEND=noninteractive
+	sudo apt-get --assume-yes remove clamav
 elif [[ $detect == *"ubuntu"* ]]; then
-	sudo apt-get remove clamav
+  export DEBIAN_FRONTEND=noninteractive
+	sudo apt-get --assume-yes remove clamav
 elif [[ $detect == *"centos"* ]]; then
     sudo yum remove -y epel-release 
     sudo yum remove -y clamav 


### PR DESCRIPTION
This PR forces non-interactive installation and uninstallation on Debian and Ubuntu so that it's consistent with other systems.